### PR TITLE
Refactor command registration

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 type Command = {
   name: string,
   callback: () => void
-}
+};
 
 // The list of commands to register in the extension
 const commands: Command[] = [

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+
+/**
+ * @type {Object} Command // Command to register with the VS Code Extension API
+ * @prop {string} command // Name of the command; e.g., 'mind-reader.selectTheme'
+ * @prop {callback} callback // Callback to register when `command` is invoked
+ */
+type Command = {
+  name: string,
+  callback: () => void
+}
+
+// The list of commands to register in the extension
+const commands: Command[] = [
+  {
+    name: 'mind-reader.selectTheme',
+
+    // callbacks can be inlined...
+    callback: () => vscode.commands.executeCommand('workbench.action.selectTheme'),
+  },
+
+  {
+    name: 'mind-reader.increaseFontScale',
+    callback: increaseFontScale, // ...or factored out into separate functions below
+  },
+
+  {
+    name: 'mind-reader.decreaseFontScale',
+    callback: decreaseFontScale,
+  },
+
+  {
+    name: 'mind-reader.resetFontScale',
+    callback: resetFontScale,
+  },
+
+  {
+    name: 'mind-reader.increaseEditorScale',
+    callback: increaseEditorScale,
+  },
+
+  {
+    name: 'mind-reader.decreaseEditorScale',
+    callback: decreaseEditorScale,
+  },
+
+  {
+    name: 'mind-reader.resetEditorScale',
+    callback: resetEditorScale,
+  },
+];
+
+// COMMAND CALLBACK IMPLEMENTATIONS
+
+function increaseFontScale(): void {
+  vscode.commands.executeCommand('editor.action.fontZoomIn');
+}
+
+function decreaseFontScale(): void {
+  vscode.commands.executeCommand('editor.action.fontZoomOut');
+}
+
+function resetFontScale(): void {
+  vscode.commands.executeCommand('editor.action.fontZoomReset');
+}
+
+function increaseEditorScale(): void {
+  vscode.commands.executeCommand('workbench.action.zoomIn');
+}
+
+function decreaseEditorScale(): void {
+  vscode.commands.executeCommand('workbench.action.zoomOut');
+}
+
+function resetEditorScale(): void {
+  vscode.commands.executeCommand('workbench.action.zoomReset');
+}
+
+export default commands;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
+
 import * as pl from './pylex';
+import commands from './commands';
 
 let parser: pl.Parser = new pl.Parser();
 
@@ -9,54 +11,14 @@ export function activate(context: vscode.ExtensionContext) {
 
   parser.parse('Beep Boop');
 
-  // Increase Font Scale
-  context.subscriptions.push(
-    vscode.commands.registerCommand('mind-reader.increaseFontScale', () => {
-      vscode.commands.executeCommand('editor.action.fontZoomIn');
-    })
-  );
-
-  // Decrease Font Scale
-  context.subscriptions.push(
-    vscode.commands.registerCommand('mind-reader.decreaseFontScale', () => {
-      vscode.commands.executeCommand('editor.action.fontZoomOut');
-    })
-  );
-
-  // Reset Font Scale
-  context.subscriptions.push(
-    vscode.commands.registerCommand('mind-reader.resetFontScale', () => {
-      vscode.commands.executeCommand('editor.action.fontZoomReset');
-    })
-  );
-
-  // Increase Editor Scale
-  context.subscriptions.push(
-    vscode.commands.registerCommand('mind-reader.increaseEditorScale', () => {
-      vscode.commands.executeCommand('workbench.action.zoomIn');
-    })
-  );
-
-  // Decrease Editor Scale
-  context.subscriptions.push(
-    vscode.commands.registerCommand('mind-reader.decreaseEditorScale', () => {
-      vscode.commands.executeCommand('workbench.action.zoomOut');
-    })
-  );
-
-  // Reset Editor Scale
-  context.subscriptions.push(
-    vscode.commands.registerCommand('mind-reader.resetEditorScale', () => {
-      vscode.commands.executeCommand('workbench.action.zoomReset');
-    })
-  );
-
-  // Select Theme
-  context.subscriptions.push(
-    vscode.commands.registerCommand('mind-reader.selectTheme', () => {
-      vscode.commands.executeCommand('workbench.action.selectTheme');
-    })
-  );
+  // Register Commands
+  commands.forEach(command => {
+    let disposable = vscode.commands.registerCommand(
+      command.name,
+      command.callback
+    );
+    context.subscriptions.push(disposable);
+  });
 }
 
 export function deactivate() {}


### PR DESCRIPTION
As we continue to register more commands for our extension, `extensions.ts` is becoming gross and hard to read.

Commands are now defined in a `commands: Command[]` list in `commands.ts`:
```typescript
type Command = {
  name: string, // Name of the command e.g. 'mind-reader.selectTheme'
  callback: () => void // Callback to register for the command
}
```
The list is imported into `extension.ts` and registered programmatically. This reduces the "extra" lines of code required to register commands in `extension.ts` from 4 per command to 7 total, without even considering the length of the callback itself.

This should help keep `extension.ts` squeaky clean :).