### PR TITLE
Add H5 & H4: Listen to Cursor/Line Context

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,13 @@
 			{
 				"command": "mind-reader.selectTheme",
 				"title": "Select Theme"
+			},
+
+			{
+				"command": "mind-reader.runLineContext",
+				"title": "Run Line Context"
 			}
+
 		],
         "keybindings": [
             {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
 			{
 				"command": "mind-reader.runLineContext",
 				"title": "Run Line Context"
+			},
+
+			{
+				"command": "mind-reader.runCursorContext",
+				"title": "Run Cursor Context"
 			}
 
 		],
@@ -151,7 +156,7 @@
 						"LEGO® Education SPIKE™ Prime Set (45678)"
 					]
 				},
-				"mindreader.screenReader": {
+				"mindreader.reader.screenReader": {
 					"type": "string",
 					"description": "Specifies which screen reader to optimize for.",
 					"default": "NVDA",
@@ -165,6 +170,11 @@
 						"Orca (Linux)",
 						"Apple VoiceOver (macOS)"
 					]
+				},
+				"mindreader.reader.contextWindow": {
+					"type": "number",
+					"description": "The number of words around the cursor to use when reading the cursor context",
+					"default": 1
 				},
 				"mindreader.connection.connectAutomatically": {
 					"type": "boolean",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -124,8 +124,8 @@ function createContextString(context: pl.LexNode[], line: number): string {
         continue;
       }
 
-      if (node.token!.type != pl.PylexSymbol.EMPTY &&
-        node.token!.type != pl.PylexSymbol.INDENT) {
+      if (node.token!.type !== pl.PylexSymbol.EMPTY &&
+        node.token!.type !== pl.PylexSymbol.INDENT) {
         contextString += ' inside ' + node.token!.type.toString();
         if (node.token!.attr) {
           contextString += ' ' + node.token!.attr.toString();

--- a/src/pylex/index.ts
+++ b/src/pylex/index.ts
@@ -4,4 +4,4 @@ export {default as LineToken} from './token';
 export {default as Lexer} from './lexer';
 export {default as LexNode} from './node';
 export {TabInfo as TabInfo} from './token';
-
+export {Symbol as PylexSymbol} from './token';

--- a/src/pylex/lexer.ts
+++ b/src/pylex/lexer.ts
@@ -159,14 +159,15 @@ export default class Lexer {
       }
       // No rules matched
 
-      // Skip this line if it is whitespace, comment, or empty
+      // TODO: move to rules
       if (/^\s*(#.*)?$/.test(line)) {
-        this.pos++;
-        continue;
+        // "empty" line
+        token = new LineToken(Symbol.EMPTY, this.pos, 999999);
+      } else {
+        // This is an INDENT token
+        token = new LineToken(Symbol.INDENT, this.pos, indent);
       }
 
-      // This is an INDENT token
-      token = new LineToken(Symbol.INDENT, this.pos, indent);
       this._currToken = token;
       this.pos++;
       return this.currToken();

--- a/src/pylex/node.ts
+++ b/src/pylex/node.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 
 import LineToken from './token';
 
+/* TODO: make accessing children and parent less tedious */
+/* TODO: 'root.children()![i])' */
 /**
  * A node in a Parse tree.
  */

--- a/src/pylex/node.ts
+++ b/src/pylex/node.ts
@@ -48,8 +48,9 @@ export default class LexNode extends vscode.TreeItem {
    * Adopt child nodes.
    *
    * @param `child` Array of nodes to adopt.
+   * @returns an updated version of itself
    */
-  adopt(children: LexNode[]): void {
+  adopt(children: LexNode[]): LexNode {
     let parentedChildren = children.map(c => new LexNode(
       c.label,
       c.collapsibleState,
@@ -66,6 +67,7 @@ export default class LexNode extends vscode.TreeItem {
       // No....
       this._children = parentedChildren;
     }
+    return this;
   }
 
   /**

--- a/src/pylex/parser.ts
+++ b/src/pylex/parser.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { EOFTOKEN, Symbol, TabInfo } from './token';
 import Lexer from './lexer';
 import LexNode from './node';
+/* TODO: update design doc */
 
 /**
  * A parse tree generator
@@ -71,8 +72,20 @@ export default class Parser {
         // go up 1 level of recursion at a time to unravel properly
         this.currIndent--;
         return children;
-      } else if (this.lexer.currToken().type === Symbol.INDENT) {
+      }
+
+      if (this.lexer.currToken().type === Symbol.INDENT ||
+          this.lexer.currToken().type === Symbol.EMPTY) {
+        const label = this.lexer.currToken().type;
         // regular code, advance and stay in same block
+        children.push(new LexNode(
+          label,
+          vscode.TreeItemCollapsibleState.None,
+          this.lexer.currToken(),
+          null,
+          parent)
+        );
+
         this.lexer.next();
         continue;
       } else {
@@ -105,29 +118,28 @@ export default class Parser {
    * @param `lineNumber` The line number to query context for.
    * @return An array of LexNodes for the root path containing `lineNumber`
    */
-  context(lineNumber: number): LexNode[] {
-    if (!this.root.children()) {
-      return [];
+  context(lineNumber: number, root?: LexNode): LexNode[] {
+    if (!root) {
+      root = this.root
     }
 
-    // Returns the LexNode that is the parent
-    // of the queried line number
-    let find = (root: LexNode): LexNode | undefined => {
-      let prevChild: LexNode;
-      for (var child of root.children()!) {
-        if (lineNumber < child.token!.linenr) {
-          if (prevChild!.children()) {
-            return find(prevChild!);
-          } else {
-            return prevChild!;
-          }
-        } else {
-          prevChild = child;
+    // is this the target?
+    if (root.token && root.token!.linenr === lineNumber) {
+      // match
+      return root.rootPath();
+    }
+
+    if (root.children()) {
+      // recursive call
+      for (let i = 0; i < root.children()!.length; i++) {
+        let ctx = this.context(lineNumber, root.children()![i]);
+        if (ctx.length > 0) {
+          // a rootpath was returned
+          return ctx;
         }
       }
-    };
-
-    let target = find(this.root);
-    return target!.rootPath();
+    }
+    // no matches
+    return [];
   }
 }

--- a/src/pylex/parser.ts
+++ b/src/pylex/parser.ts
@@ -120,7 +120,7 @@ export default class Parser {
    */
   context(lineNumber: number, root?: LexNode): LexNode[] {
     if (!root) {
-      root = this.root
+      root = this.root;
     }
 
     // is this the target?

--- a/src/pylex/token.ts
+++ b/src/pylex/token.ts
@@ -17,6 +17,7 @@ export enum Symbol {
   FINALLY = "finally",
   WITH = "with",
   INDENT = "INDENT", // Indent token, default if not EOF, only contains indent information
+  EMPTY = "EMPTY", // empty line, used only to associate with the previous line
   EOF = "EOF"
 }
 

--- a/src/test/suites/pylex/lexer.test.ts
+++ b/src/test/suites/pylex/lexer.test.ts
@@ -17,13 +17,18 @@ suite('Lexer Test Suite', () => {
   });
 
   test('Undefined', () => {
-    let l: Lexer = new Lexer('');
+    let l: Lexer = new Lexer(undefined);
     assert.deepStrictEqual(l.currToken(), EOFTOKEN);
   });
 
   test('Whitespace', () => {
     let l: Lexer = new Lexer('  \t\t'.repeat(4).repeat(4));
-    assert.deepStrictEqual(l.currToken(), EOFTOKEN);
+    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.EMPTY, 0, 999999));
+  });
+
+  test('Comment', () => {
+    let l: Lexer = new Lexer('# ur mom eats toes');
+    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.EMPTY, 0, 999999));
   });
 
   test('Non-Whitespace with no construct', () => {
@@ -118,98 +123,6 @@ suite('Lexer Test Suite', () => {
     let l: Lexer = new Lexer('with open(file as f:');
     l.restart('if is_old():');
     assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.IF, 0, 0, 'is_old()'));
-  });
-
-  test('next() ignores empty lines', () => {
-    let lines: string[] = [
-      'if wurst_available():',
-      '',
-      '    eat_wurst()'
-    ];
-    let l: Lexer = new Lexer(lines.join('\n'));
-
-    l.next();
-
-    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.INDENT, 2, 1));
-  });
-
-  test('retract() ignores empty lines', () => {
-    let lines: string[] = [
-      'if wurst_available():',
-      '',
-      '    eat_wurst()'
-    ];
-    let l: Lexer = new Lexer(lines.join('\n'));
-
-    l.next();
-
-    l.retract();
-
-    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.IF, 0, 0, 'wurst_available()'));
-  });
-
-  test('next() ignores whitespace lines', () => {
-    let lines: string[] = [
-      'if wurst_available():',
-      ' \t \t   ',
-      '    eat_wurst()'
-    ];
-    let l: Lexer = new Lexer(lines.join('\n'));
-
-    l.next();
-
-    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.INDENT, 2, 1));
-  });
-
-  test('retract() ignores whitespace lines', () => {
-    let lines: string[] = [
-      'if wurst_available():',
-      ' \t  \t   ',
-      '    eat_wurst()'
-    ];
-    let l: Lexer = new Lexer(lines.join('\n'));
-
-    // Advance to end of input
-    // Eliminates dependence on next()
-    // skipping whitespace
-    do {} while (l.next() !== EOFTOKEN);
-
-    l.retract(); // retract past EOFTOKEn
-    l.retract();
-
-    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.IF, 0, 0, 'wurst_available()'));
-  });
-
-  test('next() ignores comment lines', () => {
-    let lines: string[] = [
-      'if wurst_available():',
-      ' \t # I hate testing \t',
-      '    eat_wurst()'
-    ];
-    let l: Lexer = new Lexer(lines.join('\n'));
-
-    l.next();
-
-    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.INDENT, 2, 1));
-  });
-
-  test('retract() ignores comment lines', () => {
-    let lines: string[] = [
-      'if wurst_available():',
-      ' \t # \t',
-      '    eat_wurst()'
-    ];
-    let l: Lexer = new Lexer(lines.join('\n'));
-
-    // Advance to end of input
-    // Eliminates dependence on next()
-    // skipping comment
-    do {} while (l.next() !== EOFTOKEN);
-
-    l.retract(); // retract past EOFTOKEn
-    l.retract();
-
-    assert.deepStrictEqual(l.currToken(), new LineToken(Symbol.IF, 0, 0, 'wurst_available()'));
   });
 
   test('next() out of range', () => {

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-
-import LexNode from '../pylex/node';
+import { LineToken, PylexSymbol, LexNode} from '../pylex';
 
 /**
  * TODO: Eliminate need for me.
@@ -50,8 +49,20 @@ function root(nodes: LexNode[] | null): LexNode {
   );
 }
 
+/* short hand for returning an indentation token for a certain line and indentation */
+function indent(linenr: number, indentLevel: number): LexNode {
+  return new LexNode('INDENT', 0, new LineToken(PylexSymbol.INDENT, linenr, indentLevel));
+}
+
+/* short hand for returning an empty token for a certain line*/
+function empty(linenr: number): LexNode {
+  return new LexNode('EMPTY', 0, new LineToken(PylexSymbol.EMPTY, linenr, 999999));
+}
+
 
 export {
   deparent,
   root,
+  indent,
+  empty
 };


### PR DESCRIPTION
Adds `mind-reader.runLineContext` command that gathers line context from the document and outputs a formatted context string.

Adds `mind-reader.runCursorContext` command that outputs a window of words around the cursor which can be configured using `mindreader.reader.contextWindow`.